### PR TITLE
indicate usage for python3.6 in readme

### DIFF
--- a/README
+++ b/README
@@ -16,7 +16,7 @@ Install python-ngram from `PyPI`_ using `pip installer`_::
 
    pip install ngram
 
-It should run on Python 2.6, Python 2.7 and Python 3.2
+It should run on Python 2.6, Python 2.7 and Python 3.6
 
 How does it work?
 =================


### PR DESCRIPTION
Judging from the tox file this package seems to be ready for python3.6. I would have passed on using this if I hadn't looked at the tox file, so I figured I could help make sure others don't make that mistake. 

Let me know if you need anything else!